### PR TITLE
Fix Stack Comments

### DIFF
--- a/src/PriceFeedConsumer.huff
+++ b/src/PriceFeedConsumer.huff
@@ -24,7 +24,7 @@
     // arguments size = 0x04 (function selector size)
     // arguments offset = 0x1c // Since our function selector is only 4 bytes, we have to shift over 28 bytes to get the selector in memory
     // address = PRICE_FEED_ADDRESS
-    // gas = whatever gas is left = gas
+    // gas = whatever gas is left
     // staticcall calls our PRICE_FEED_ADDRESS contract 
     0x00 0x00 0x04 0x1c [PRICE_FEED_ADDRESS] gas staticcall // [success]
 
@@ -35,19 +35,19 @@
     // https://ethereum.stackexchange.com/questions/132961/call-another-contract-with-huff
 
     // store part of the returndata in memory
-    0x20           // [datasize, success] // We only want the int256 which is at the 2nd position
-    0x20           // [offset, datasize, success] // We want the int256 only which is 32 bytes (0x20)
-    0x00           // [destOffset, offset, datasize, success]
-    returndatacopy // [success] 
+    0x20           // [datasize, iszero_result] // We only want the int256 which is at the 2nd position
+    0x20           // [offset, datasize, iszero_result] // We want the int256 only which is 32 bytes (0x20)
+    0x00           // [destOffset, offset, datasize, iszero_result]
+    returndatacopy // [iszero_result] 
 
-    0x20           // [datasize, success]
-    0x00           // [mem_offset, datasize, success]
-    return
+    0x20           // [datasize, iszero_result]
+    0x00           // [mem_offset, datasize, iszero_result]
+    return         // [iszero_result]
 
     // If the call to the contract fails, we revert
     fail:
         0x00 0x00
-        revert
+        revert 
 }
 
 


### PR DESCRIPTION
After the staticcall the result is pushed to the stack, but after we use the iszero opcode, it is popped off the stack, and the result from the iszero is pushed onto the stack.

In this case, it's just 0x00 because iszero returned false because staticcall returned true 0x01.