### PR TITLE
Fix Memory Management

### DIFF
--- a/src/KeepersConsumer.huff
+++ b/src/KeepersConsumer.huff
@@ -46,7 +46,8 @@
 
 #define macro CHECK_UPKEEP_RETURNS() = takes (0) returns (0) {
     // First, we populate the stack from CHECK_UPKEEP
-    CHECK_UPKEEP() // [0x00, 0x20, 0x00, time_comparison]
+    CHECK_UPKEEP() // [time_comparison]
+    0x00 0x20 0x00 // [0x00, 0x20, 0x00, time_comparison]
     mstore mstore // Then, we store the values in memory. The time_comparison result, and an empty bytes object.
     0x40 0x00 return // Then we return it all!
 }
@@ -62,17 +63,13 @@
     // Put the interval on the stack, and then compare
     [INTERVAL]                            // [INTERVAL, different_in_time]
     lt                                    // [time_comparison]
-    0x00                                  // [0x00, time_comparison]
-
-    0x00 0x20                             // [0x00, 0x20, 0x00, time_comparison]
 }
 
 #define macro PERFORM_UPKEEP() = takes (0) returns (0) {
     // We just totally ignore the bytes calldata if sent
 
     // First, we make sure checkupkeep is good
-    CHECK_UPKEEP()                         // [0x00, 0x20, 0x00, time_comparison]
-    pop pop pop                            // [time_comparison] 
+    CHECK_UPKEEP()                         // [time_comparison]
     iszero                                 // [time_comparison == 0] 
 
     // Revert if checkUpkeep is false!

--- a/src/KeepersConsumer.huff
+++ b/src/KeepersConsumer.huff
@@ -47,7 +47,7 @@
 #define macro CHECK_UPKEEP_RETURNS() = takes (0) returns (0) {
     // First, we populate the stack from CHECK_UPKEEP
     CHECK_UPKEEP() // [time_comparison]
-    0x00 0x20 0x00 // [0x00, 0x20, 0x00, time_comparison]
+    0x00 0x00 0x20 // [0x20, 0x00, 0x00, time_comparison]
     mstore mstore // Then, we store the values in memory. The time_comparison result, and an empty bytes object.
     0x40 0x00 return // Then we return it all!
 }


### PR DESCRIPTION
In KeepersConsumer.CHECK_UPKEEP() you pushed four values to the stack, which meant that in PERFROM_UPKEEP, you had to pop three items off to use the time_comparison.

This was unnecessary since only the CHECK_UPKEEP() function uses those values. I pushed them onto the stack inside the CHECK_UPKEEP() function. This means we save at least nine gas in the PERFORM_UPKEEP() function because we got rid of the three pop opcodes.

This makes the code more readable, cleaner, and optimized.